### PR TITLE
Add RESTful API using sqlx connection pool & PostgreSQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ debug/
 target/
 /target/
 scenario1/
+.env
 
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html

--- a/ezytutors/Cargo.toml
+++ b/ezytutors/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [workspace]
-members = ["tutor-nodb"]
+members = ["tutor-nodb", "tutor-db"]
 
 [dependencies]

--- a/ezytutors/tutor-db/.env
+++ b/ezytutors/tutor-db/.env
@@ -1,0 +1,1 @@
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/ezytutors

--- a/ezytutors/tutor-db/.env
+++ b/ezytutors/tutor-db/.env
@@ -1,1 +1,1 @@
-DATABASE_URL=postgres://postgres:postgres@localhost:5432/ezytutors
+DATABASE_URL=postgres://postgres:ezytutors@localhost:5432/ezytutors

--- a/ezytutors/tutor-db/Cargo.toml
+++ b/ezytutors/tutor-db/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "tutor-db"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+# Actix 웹 프레임워크 및 런타임.
+actix-web = "4.9.0"
+actix-rt = "2.10.0"
+
+# 환경 변수 접근 라이브러리.
+dotenv = "0.15.0"
+
+# Postgres 접근 라이브러리
+sqlx = {version = "0.8.1", default-features = false, features = ["postgres", "runtime-tokio", "macros", "chrono"]}
+sqlx-postgres = "0.8.1"
+
+# Data 직렬화 라이브러리.
+serde = {version = "1.0.209", features = ["derive"]}
+
+# 기타 유틸리티.
+chrono = {version = "0.4.38", features = ["serde"]}
+
+# 바이너리 빌드용 Openssl.
+openssl = {version = "0.10.66", features = ["vendored"]}

--- a/ezytutors/tutor-db/iter3-test-clean.sql
+++ b/ezytutors/tutor-db/iter3-test-clean.sql
@@ -1,0 +1,1 @@
+DELETE FROM ezy_course_ch4 WHERE course_id = 8;

--- a/ezytutors/tutor-db/src/bin/iter1.rs
+++ b/ezytutors/tutor-db/src/bin/iter1.rs
@@ -1,0 +1,45 @@
+use dotenv::dotenv;
+use std::{env, io};
+use tsd::io;
+use sqlx::postgres::PgPool;
+use chrono::NaiveDateTime;
+
+#[derive(Debug)]
+pub struct Course {
+    pub course_id: i32,
+    pub tutor_id: i32,
+    pub course_name: String,
+    pub posted_time: Option<NaiveDateTime>,
+}
+
+// 비동기 Actic 웹 서버 실행 후, sqlx로 db연결.
+#[actix_rt::main]
+async fn main() -> io::Result<()> {
+    // 메모리에 환경 변수 로드.
+    dotenv.ok();
+    let database_url = env::var("DATABASE_URL").expect(
+        "DATABASE_URL is not set in .env file");
+
+        // sqlx로 db 커넥션 풀 생성.
+    let db_pool = PgPool::connect(&database_url).await().unwrap();
+
+    let course_rows = sqlx::query!(
+        r#"select course_id, tutor_id, course_name, posted_time from ezy_course_ch4 where course_id = $1"#, 1
+    )
+    .fetch_all(&db_pool)
+    .await
+    .unwrap();
+
+    let mut courses_list = vec![];
+    for course_row in course_rows {
+        courses_list.push(Course {
+            course_id: course_row.course_id,
+            tutor_id: course_row.tutor_id,
+            course_name: course_row.course_name,
+            posted_time: Some(chrono::NaiveDateTime::from(course_row.posted_time.unwrap())),
+        })
+    }
+    println!("Courses = {:?}", courses_list);
+    Ok(())
+
+}

--- a/ezytutors/tutor-db/src/bin/iter1.rs
+++ b/ezytutors/tutor-db/src/bin/iter1.rs
@@ -1,6 +1,5 @@
 use dotenv::dotenv;
 use std::{env, io};
-use tsd::io;
 use sqlx::postgres::PgPool;
 use chrono::NaiveDateTime;
 
@@ -16,12 +15,12 @@ pub struct Course {
 #[actix_rt::main]
 async fn main() -> io::Result<()> {
     // 메모리에 환경 변수 로드.
-    dotenv.ok();
+    dotenv().ok();
     let database_url = env::var("DATABASE_URL").expect(
         "DATABASE_URL is not set in .env file");
 
         // sqlx로 db 커넥션 풀 생성.
-    let db_pool = PgPool::connect(&database_url).await().unwrap();
+    let db_pool = PgPool::connect(&database_url).await.unwrap();
 
     let course_rows = sqlx::query!(
         r#"select course_id, tutor_id, course_name, posted_time from ezy_course_ch4 where course_id = $1"#, 1

--- a/ezytutors/tutor-db/src/bin/iter2.rs
+++ b/ezytutors/tutor-db/src/bin/iter2.rs
@@ -1,0 +1,43 @@
+use actix_web::{web, App, HttpServer};
+use dotenv::dotenv;
+use sqlx::postgres::PgPool;
+use std::env;
+use std::io;
+use std::sync::Mutex;
+
+#[path = "../iter2/handlers.rs"]
+mod handlers;
+#[path = "../iter2/models.rs"]
+mod models;
+#[path = "../iter2/routes.rs"]
+mod routes;
+#[path = "../iter2/state.rs"]
+mod state;
+
+use routes::*;
+use state::AppState;
+
+#[actix_rt::main]
+async fn main() -> io::Result<()> {
+    dotenv().ok();
+
+    let database_url = env::var("DATABASE_URL").expect(
+        "DATABASE_URL is not set in .env file");
+
+    let db_pool = PgPool::connect(&database_url).await.unwrap();
+
+    let shared_data = web::Data::new(AppState {
+        health_check_response: "I'm stay'in alive. You've already asked me ".to_string(),
+        visit_count: Mutex::new(0),
+        db: db_pool,
+    });
+
+    let app = move || {
+        App::new()
+            .app_data(shared_data.clone())
+            .configure(general_routes)
+            .configure(course_routes)
+    };
+
+    HttpServer::new(app).bind("127.0.0.1:3000")?.run().await
+}

--- a/ezytutors/tutor-db/src/bin/iter3.rs
+++ b/ezytutors/tutor-db/src/bin/iter3.rs
@@ -1,0 +1,44 @@
+use actix_web::{web, App, HttpServer};
+use dotenv::dotenv;
+use sqlx::postgres::PgPool;
+use std::env;
+use std::io;
+use std::sync::Mutex;
+
+#[path ="../iter3/db_access.rs"]
+mod db_access;
+#[path ="../iter3/handlers.rs"]
+mod handlers;
+#[path ="../iter3/models.rs"]
+mod models;
+#[path ="../iter3/routes.rs"]
+mod routes;
+#[path ="../iter3/state.rs"]
+mod state;
+
+use routes::*;
+use state::AppState;
+
+#[actix_rt::main]
+async fn main() -> io::Result<()> {
+    dotenv().ok();
+
+    let database_url = env::var("DATABASE_URL").expect(
+        "DATABASE_URL is not set in .env file");
+    let dp_pool = PgPool::connect(&database_url).await.unwrap();
+
+    let shared_data = web::Data::new(AppState {
+        health_check_response: "I'm stay'in alive. You've already asked me ".to_string(),
+        visit_count: Mutex::new(0),
+        db: dp_pool,
+    });
+
+    let app = move || {
+        App::new()
+            .app_data(shared_data.clone()) // app 상태 인스턴스에 주입
+            .configure(general_routes)
+            .configure(course_routes)
+    };
+
+    HttpServer::new(app).bind("127.0.0.1:3000")?.run().await
+}

--- a/ezytutors/tutor-db/src/database.sql
+++ b/ezytutors/tutor-db/src/database.sql
@@ -1,0 +1,19 @@
+/* 테이블이 존재하면 삭제 */
+drop table if exists ezy_course_ch4;
+
+/* 테이블 생성 */
+create table ezy_course_ch4
+(
+    course_id serial primary key,
+    tutor_id INT not null,
+    course_name varchar(140) not null,
+    posted_time TIMESTAMP default now()
+);
+
+
+/* 테스트용 시드 데이터 로드 */
+insert into ezy_course_ch4 (course_id, tutor_id, course_name, posted_time)
+values (1, 1, '스프링 MVC 1편 - 백엔드 웹 개발 핵심 기술', '2024-08-27 14:09:08');
+
+insert into ezy_course_ch4 (course_id, tutor_id, course_name, posted_time)
+values (2, 1, '스프링 DB 1편 - 데이터 접근 핵심 원리', '2024-08-27 14:10:52');

--- a/ezytutors/tutor-db/src/iter2/handlers.rs
+++ b/ezytutors/tutor-db/src/iter2/handlers.rs
@@ -31,3 +31,89 @@ pub async fn post_new_course(
 ) -> HttpResponse {
     HttpResponse::Ok().json("Success")
 }
+
+
+// 각 핸들러 함수 단위 테스트.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::http::StatusCode;
+    use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
+    use dotenv::dotenv;
+    use sqlx::postgres::PgPool;
+    use std::env;
+    use std::sync::Mutex;
+
+    #[actix_rt::test]
+    async fn get_all_courses_success() {
+        dotenv().ok();
+
+        let database_url = env::var("DATABASE_URL").expect(
+            "DATABASE_URL is not set in .env file");
+
+        let pool = PgPool::connect(&database_url).await.unwrap();
+
+        let app_state: web::Data<AppState> = web::Data::new(AppState {
+            health_check_response: "".to_string(),
+            visit_count: Mutex::new(0),
+            db: pool,
+        });
+
+        let tutor_id = web::Path::from((1, ));
+        let resp = get_courses_for_tutor(app_state, tutor_id).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[actix_rt::test]
+    async fn get_course_details_test() {
+        dotenv().ok();
+
+        let database_url = env::var("DATABASE_URL").expect(
+            "DATABASE_URL is not set in .env file");
+
+        let pool = PgPool::connect(&database_url).await.unwrap();
+
+        let app_state = web::Data::new(AppState {
+            health_check_response: "".to_string(),
+            visit_count: Mutex::new(0),
+            db: pool,
+        });
+
+        let params = web::Path::from((1, 2));
+        let resp = get_course_details(app_state, params).await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[actix_rt::test]
+    async fn post_course_success() {
+        dotenv().ok();
+
+        let database_url = env::var("DATABASE_URL").expect(
+            "DATABASE_URL is not set in .env file");
+
+        let pool = PgPool::connect(&database_url).await.unwrap();
+
+        let app_state = web::Data::new(AppState {
+            health_check_response: "".to_string(),
+            visit_count: Mutex::new(0),
+            db: pool,
+        });
+
+        let date = NaiveDate::from_ymd_opt(2024, 9, 3).unwrap();
+        let time = NaiveTime::from_hms_opt(21, 31, 33).unwrap();
+        let posted_time = NaiveDateTime::new(date, time);
+
+        let new_course_msg = Course {
+            course_id: 1,
+            tutor_id: 1,
+            course_name: "모든 개발자를 위한 HTTP 웹 기본 지식".into(),
+            posted_time: Some(posted_time),
+        };
+
+        let course_param = web::Json(new_course_msg);
+        let resp = post_new_course(course_param, app_state).await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}

--- a/ezytutors/tutor-db/src/iter2/handlers.rs
+++ b/ezytutors/tutor-db/src/iter2/handlers.rs
@@ -1,0 +1,33 @@
+// 그냥 에러 확인용 스켈레톤 코드임. 별 동작 없음.
+use super::models::Course;
+use super::state::AppState;
+use actix_web::{web, HttpResponse};
+
+pub async fn health_check_handler(app_state: web::Data<AppState>) -> HttpResponse {
+    let health_check_response = &app_state.health_check_response;
+    let mut visit_count = app_state.visit_count.lock().unwrap();
+    let response = format!("{} {} times", health_check_response, visit_count);
+    *visit_count += 1;
+    HttpResponse::Ok().json(&response)
+}
+
+pub async fn get_courses_for_tutor(
+    _app_state: web::Data<AppState>,
+    _params: web::Path<(i32,)>,
+) -> HttpResponse {
+    HttpResponse::Ok().json("Success")
+}
+
+pub async fn get_course_details(
+    _app_state: web::Data<AppState>,
+    _params: web::Path<(i32, i32)>,
+) -> HttpResponse {
+    HttpResponse::Ok().json("Success")
+}
+
+pub async fn post_new_course(
+    _new_course: web::Json<Course>,
+    _app_state: web::Data<AppState>
+) -> HttpResponse {
+    HttpResponse::Ok().json("Success")
+}

--- a/ezytutors/tutor-db/src/iter2/models.rs
+++ b/ezytutors/tutor-db/src/iter2/models.rs
@@ -1,0 +1,22 @@
+use actix_web::web;
+use chrono::NaiveDateTime;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct Course {
+    pub course_id: i32,
+    pub tutor_id: i32,
+    pub course_name: String,
+    pub posted_time: Option<NaiveDateTime>,
+}
+
+impl From<web::Json<Course>> for Course {
+    fn from(course: web::Json<Course>) -> Self {
+        Course {
+            course_id: course.course_id,
+            tutor_id: course.tutor_id,
+            course_name: course.course_name.clone(),
+            posted_time: course.posted_time,
+        }
+    }
+}

--- a/ezytutors/tutor-db/src/iter2/routes.rs
+++ b/ezytutors/tutor-db/src/iter2/routes.rs
@@ -1,0 +1,17 @@
+use super::handlers::*;
+use actix_web::web;
+
+// 헬스 체크같은 보편적인 라우트.
+pub fn general_routes(cfg: &mut web::ServiceConfig) {
+    cfg.route("/health", web::get().to(health_check_handler));
+}
+
+// 강의 관련 라우트.
+pub fn course_routes(cfg: &mut web::ServiceConfig) {
+    cfg.service(
+        web::scope("/courses")
+            .route("/", web::post().to(post_new_course))
+            .route("/{tutor_id}", web::get().to(get_courses_for_tutor))
+            .route("/{tutor_id}/{course_id}", web::get().to(get_course_details)),
+    );
+}

--- a/ezytutors/tutor-db/src/iter2/state.rs
+++ b/ezytutors/tutor-db/src/iter2/state.rs
@@ -1,0 +1,8 @@
+use sqlx::postgres::PgPool;
+use std::sync::Mutex;
+
+pub struct AppState {
+    pub health_check_response: String,
+    pub visit_count: Mutex<u32>,
+    pub db: PgPool,
+}

--- a/ezytutors/tutor-db/src/iter3/db_access.rs
+++ b/ezytutors/tutor-db/src/iter3/db_access.rs
@@ -1,0 +1,61 @@
+use super::models::Course;
+use sqlx::postgres::PgPool;
+
+pub async fn get_courses_for_tutor_db(pool: &PgPool, tutor_id: i32) -> Vec<Course> {
+    // SQL 구문 생성.
+    let course_rows = sqlx::query!(
+        "SELECT tutor_id, course_id, course_name, posted_time FROM
+        ezy_course_ch4 WHERE tutor_id = $1",
+        tutor_id
+    )
+    .fetch_all(pool) // 쿼리 실행해서 커넥션 풀에 전달.
+    .await
+    .unwrap();
+
+    // 결과 추출 후, Vector로 변환.
+    course_rows
+        .iter()
+        .map(|course_row| Course {
+            tutor_id: course_row.tutor_id,
+            course_id: course_row.course_id,
+            course_name: course_row.course_name.clone(),
+            posted_time: Some(chrono::NaiveDateTime::from(course_row.posted_time.unwrap())),
+        })
+        .collect()
+}
+
+pub async fn get_course_for_details_db(pool: &PgPool, tutor_id: i32, course_id: i32) -> Course {
+    // SQL 구문 생성.
+    let course_row = sqlx::query!(
+        "SELECT tutor_id, course_id, course_name, posted_time FROM
+        ezy_course_ch4 WHERE tutor_id = $1 AND course_id = $2",
+        tutor_id, course_id
+    )
+    .fetch_one(pool)
+    .await
+    .unwrap();
+
+    // 쿼리 실행 후 결과를 Course 구조체로 반환.
+    Course {
+        tutor_id: course_row.tutor_id,
+        course_id: course_row.course_id,
+        course_name: course_row.course_name.clone(),
+        posted_time: Some(chrono::NaiveDateTime::from(course_row.posted_time.unwrap())),
+    }
+}
+
+pub async fn post_new_course_db(pool: &PgPool, new_course: Course) -> Course {
+    // SQL 구문 생성.
+    let course_row = sqlx::query!("INSERT INTO ezy_course_ch4 (
+    tutor_id, course_id, course_name) VALUES ($1, $2, $3) RETURNING tutor_id, course_id, course_name, posted_time", new_course.tutor_id, new_course.course_id, new_course.course_name)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+
+    Course {
+        tutor_id: course_row.tutor_id,
+        course_id: course_row.course_id,
+        course_name: course_row.course_name.clone(),
+        posted_time: Some(chrono::NaiveDateTime::from(course_row.posted_time.unwrap())),
+    }
+}

--- a/ezytutors/tutor-db/src/iter3/handlers.rs
+++ b/ezytutors/tutor-db/src/iter3/handlers.rs
@@ -1,0 +1,127 @@
+use super::db_access::*;
+use super::models::Course;
+use super::state::AppState;
+use actix_web::{web, HttpResponse};
+
+pub async fn health_check_handler(app_state: web::Data<AppState>) -> HttpResponse {
+    let health_check_response = &app_state.health_check_response;
+    let mut visit_count = app_state.visit_count.lock().unwrap();
+    let response = format!("{} {} times", health_check_response, visit_count);
+    *visit_count += 1;
+    
+    HttpResponse::Ok().json(&response)
+}
+
+pub async fn get_courses_for_tutor(
+    app_state: web::Data<AppState>,
+    params: web::Path<(i32, )>,
+) -> HttpResponse {
+    let tutor_id = params.0;
+    let courses = get_courses_for_tutor_db(&app_state.db, tutor_id).await;
+
+    HttpResponse::Ok().json(courses)
+}
+
+pub async fn get_course_for_details(
+    app_state: web::Data<AppState>,
+    params: web::Path<(i32, i32)>,
+) -> HttpResponse {
+    let (tutor_id, course_id) = (params.0, params.1);
+    let course = get_course_for_details_db(&app_state.db, tutor_id, course_id).await;
+
+    HttpResponse::Ok().json(course)
+}
+
+pub async fn post_new_course(
+    app_state: web::Data<AppState>,
+    new_course: web::Json<Course>,
+) -> HttpResponse {
+    let course = post_new_course_db(&app_state.db, new_course.into()).await;
+
+    HttpResponse::Ok().json(course)
+}
+
+// 각 핸들러 함수 단위 테스트.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::http::StatusCode;
+    use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
+    use dotenv::dotenv;
+    use sqlx::postgres::PgPool;
+    use std::env;
+    use std::sync::Mutex;
+
+    #[actix_rt::test]
+    async fn get_all_courses_success() {
+        dotenv().ok();
+
+        let database_url = env::var("DATABASE_URL").expect(
+            "DATABASE_URL is not set in .env file");
+
+        let pool = PgPool::connect(&database_url).await.unwrap();
+
+        let app_state: web::Data<AppState> = web::Data::new(AppState {
+            health_check_response: "".to_string(),
+            visit_count: Mutex::new(0),
+            db: pool,
+        });
+
+        let tutor_id = web::Path::from((1, ));
+        let resp = get_courses_for_tutor(app_state, tutor_id).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[actix_rt::test]
+    async fn get_course_details_test() {
+        dotenv().ok();
+
+        let database_url = env::var("DATABASE_URL").expect(
+            "DATABASE_URL is not set in .env file");
+
+        let pool = PgPool::connect(&database_url).await.unwrap();
+
+        let app_state = web::Data::new(AppState {
+            health_check_response: "".to_string(),
+            visit_count: Mutex::new(0),
+            db: pool,
+        });
+
+        let params = web::Path::from((1, 2));
+        let resp = get_course_for_details(app_state, params).await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[actix_rt::test]
+    async fn post_course_success() {
+        dotenv().ok();
+
+        let database_url = env::var("DATABASE_URL").expect(
+            "DATABASE_URL is not set in .env file");
+
+        let pool = PgPool::connect(&database_url).await.unwrap();
+
+        let app_state = web::Data::new(AppState {
+            health_check_response: "".to_string(),
+            visit_count: Mutex::new(0),
+            db: pool,
+        });
+
+        let date = NaiveDate::from_ymd_opt(2024, 9, 3).unwrap();
+        let time = NaiveTime::from_hms_opt(21, 31, 33).unwrap();
+        let posted_time = NaiveDateTime::new(date, time);
+
+        let new_course_msg = Course {
+            course_id: 9,
+            tutor_id: 1,
+            course_name: "모든 개발자를 위한 HTTP 웹 기본 지식".into(),
+            posted_time: Some(posted_time),
+        };
+
+        let course_param = web::Json(new_course_msg);
+        let resp = post_new_course(app_state, course_param).await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}

--- a/ezytutors/tutor-db/src/iter3/models.rs
+++ b/ezytutors/tutor-db/src/iter3/models.rs
@@ -1,0 +1,22 @@
+use actix_web::web;
+use chrono::NaiveDateTime;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct Course {
+    pub tutor_id: i32,
+    pub course_id: i32,
+    pub course_name: String,
+    pub posted_time: Option<NaiveDateTime>,
+}
+
+impl From<web::Json<Course>> for Course {
+    fn from(course: web::Json<Course>) -> Self {
+        Course {
+            tutor_id: course.tutor_id,
+            course_id: course.course_id,
+            course_name: course.course_name.clone(),
+            posted_time: course.posted_time,
+        }
+    }
+}

--- a/ezytutors/tutor-db/src/iter3/routes.rs
+++ b/ezytutors/tutor-db/src/iter3/routes.rs
@@ -1,0 +1,17 @@
+use super::handlers::*;
+use actix_web::web;
+
+// 헬스 체크같은 보편적인 라우트.
+pub fn general_routes(cfg: &mut web::ServiceConfig) {
+    cfg.route("/health", web::get().to(health_check_handler));
+}
+
+// 강의 관련 라우트.
+pub fn course_routes(cfg: &mut web::ServiceConfig) {
+    cfg.service(
+        web::scope("/courses")
+            .route("/", web::post().to(post_new_course))
+            .route("/{tutor_id}", web::get().to(get_courses_for_tutor))
+            .route("/{tutor_id}/{course_id}", web::get().to(get_course_for_details)),
+    );
+}

--- a/ezytutors/tutor-db/src/iter3/state.rs
+++ b/ezytutors/tutor-db/src/iter3/state.rs
@@ -1,0 +1,8 @@
+use sqlx::postgres::PgPool;
+use std::sync::Mutex;
+
+pub struct AppState {
+    pub health_check_response: String,
+    pub visit_count: Mutex<u32>,
+    pub db: PgPool,
+}


### PR DESCRIPTION
PostgreSQL을 사용해서 DB 기반 서비스 제작.
sqlx 크레이트를 사용해서 Postgres db에 비동기 접근.


sql 커넥션 풀 생성해서 AppState 구성.
```
let dp_pool = PgPool::connect(&database_url).await.unwrap();

let shared_data = web::Data::new(AppState { ... db: dp_pool, ...});
```

Actix 웹 애플리케이션 인스턴스에 주입
```
.app_data(shared_data.clone())
```

프로젝트 범위 및 구조
```
tutor-db\
    ├── src\
    │   └── bin\
    │   │   ├── iter1.rs: sqlx로 Postgres db 연결 확인 테스트.
    │   │   ├── iter2.rs
    │   │   └── iter3.rs
    │   └── iter2\: sqlx 커넥션 풀 생성하고, AppState에 추가 -> Actix 웹 애플리케이션 인스턴스에 디펜던시 주입.
    │   │   ├── handlers.rs
    │   │   ├── models.rs
    │   │   ├── routes.rs
    │   │   └── state.rs
    │   └── iter3\: 
    │   │   ├── db_access.rs: srp 준수를 위해 핸들러에서 데이터베이스 접근 로직 분리.
    │   │   ├── handlers.rs
    │   │   ├── models.rs
    │   │   ├── routes.rs
    │   │   └── state.rs
    │   ├── database.sql: PostgreSQL 데이터베이스 테이블 생성용 스크립트.
    ├── .env: DATABASE_URL 환경 변수 세팅.
    └── Cargo.toml
    └── iter3-test-clean.sql: iter3 테스트 시, 중복 강의 번호 레코드 삭제하는 sql.
```

Actix에서 sqlx로 db 연결할 때, main에서 sql connection pool 생성 -> application state에 주입 -> handler에서 connection pool에 접근, db access 함수에 전달 -> sqlx::query!()로 쿼리 생성 후, 커넥션 풀을 사용해 쿼리 실행.

iter1, 2, 3 단계별로 db 적용 심화.
1. iter1에선 db 설정 및 sqlx 커넥션 설정 후 커넥션 테스트.
2. iter2에선 db 연결 웹 서비스 제작.
3. iter3에선 핸들러에서 db 접근 로직 분리,