### PR TITLE
Refactor: implement custom error type conversion and handling

### DIFF
--- a/ezytutors/tutor-db/.env
+++ b/ezytutors/tutor-db/.env
@@ -1,1 +1,2 @@
 DATABASE_URL=postgres://postgres:ezytutors@localhost:5432/ezytutors
+HOST_PORT=127.0.0.1:3000

--- a/ezytutors/tutor-db/src/bin/iter4.rs
+++ b/ezytutors/tutor-db/src/bin/iter4.rs
@@ -1,0 +1,48 @@
+use actix_web::{web, App, HttpServer};
+use dotenv::dotenv;
+use sqlx::postgres::PgPool;
+use std::env;
+use std::io;
+use std::sync::Mutex;
+
+#[path = "../iter4/db_access.rs"]
+mod db_access;
+#[path = "../iter4/errors.rs"]
+mod errors;
+#[path = "../iter4/handlers.rs"]
+mod handlers;
+#[path = "../iter4/models.rs"]
+mod models;
+#[path = "../iter4/routes.rs"]
+mod routes;
+#[path = "../iter4/state.rs"]
+mod state;
+
+use routes::*;
+use state::AppState;
+
+#[actix_rt::main]
+async fn main() -> io::Result<()> {
+    dotenv().ok();
+
+    let database_url = env::var("DATABASE_URL").expect(
+        "DATABASE_URL is not set in .env file");
+    let dp_pool = PgPool::connect(&database_url).await.unwrap();
+
+    let shared_data = web::Data::new(AppState {
+        health_check_response: "I'm stay'in alive. You've already asked me ".to_string(),
+        visit_count: Mutex::new(0),
+        db: dp_pool,
+    });
+
+    let app = move || {
+        App::new()
+            .app_data(shared_data.clone()) // app 상태 인스턴스에 주입
+            .configure(general_routes)
+            .configure(course_routes)
+    };
+
+    let host_port = env::var("HOST_PORT").expect(
+        "HOST:PORT address is not set in .env file");
+    HttpServer::new(app).bind(&host_port)?.run().await
+}

--- a/ezytutors/tutor-db/src/database.sql
+++ b/ezytutors/tutor-db/src/database.sql
@@ -1,8 +1,8 @@
 /* 테이블이 존재하면 삭제 */
-drop table if exists ezy_course_ch4;
+drop table if exists ezy_course_ch5;
 
 /* 테이블 생성 */
-create table ezy_course_ch4
+create table ezy_course_ch5
 (
     course_id serial primary key,
     tutor_id INT not null,
@@ -12,8 +12,8 @@ create table ezy_course_ch4
 
 
 /* 테스트용 시드 데이터 로드 */
-insert into ezy_course_ch4 (course_id, tutor_id, course_name, posted_time)
-values (1, 1, '스프링 MVC 1편 - 백엔드 웹 개발 핵심 기술', '2024-08-27 14:09:08');
+insert into ezy_course_ch5 (course_id, tutor_id, course_name, posted_time)
+values (1, 1, '스프링 MVC 1편 - 백엔드 웹 개발 핵심 기술', '2024-09-06 21:07:08');
 
-insert into ezy_course_ch4 (course_id, tutor_id, course_name, posted_time)
-values (2, 1, '스프링 DB 1편 - 데이터 접근 핵심 원리', '2024-08-27 14:10:52');
+insert into ezy_course_ch5 (course_id, tutor_id, course_name, posted_time)
+values (2, 1, '스프링 DB 1편 - 데이터 접근 핵심 원리', '2024-09-06 14:07:17');

--- a/ezytutors/tutor-db/src/iter4/db_access.rs
+++ b/ezytutors/tutor-db/src/iter4/db_access.rs
@@ -1,0 +1,68 @@
+use super::errors::EzyTutorError;
+use super::models::Course;
+use sqlx::postgres::PgPool;
+
+pub async fn get_courses_for_tutor_db(pool: &PgPool, tutor_id: i32) -> Result<Vec<Course>, EzyTutorError> {
+    // SQL 구문 생성.
+    let course_rows = sqlx::query!(
+        "SELECT tutor_id, course_id, course_name, posted_time FROM
+        ezy_course_ch4 WHERE tutor_id = $1",
+        tutor_id
+    )
+    .fetch_all(pool) // 쿼리 실행해서 커넥션 풀에 전달.
+    .await?;
+
+    // 결과 추출 후, Vector로 변환.
+    let courses: Vec<Course> = course_rows
+        .iter()
+        .map(|course_row| Course {
+            tutor_id: course_row.tutor_id,
+            course_id: course_row.course_id,
+            course_name: course_row.course_name.clone(),
+            posted_time: Some(chrono::NaiveDateTime::from(course_row.posted_time.unwrap())),
+        })
+        .collect();
+    match courses.len() {
+        0 => Err(EzyTutorError::NotFound("Courses not found for tutor".into(),)),
+        _ => Ok(courses),
+    }
+}
+
+pub async fn get_course_for_details_db(pool: &PgPool, tutor_id: i32, course_id: i32) -> Result<Course, EzyTutorError> {
+    // SQL 구문 생성.
+    let course_row = sqlx::query!(
+        "SELECT tutor_id, course_id, course_name, posted_time FROM
+        ezy_course_ch4 WHERE tutor_id = $1 AND course_id = $2",
+        tutor_id, course_id
+    )
+    .fetch_one(pool)
+    .await;
+
+    if let Ok(course_row) = course_row {
+        // 쿼리 실행 후 결과를 Course 구조체로 반환.
+        Ok(Course {
+            tutor_id: course_row.tutor_id,
+            course_id: course_row.course_id,
+            course_name: course_row.course_name.clone(),
+            posted_time: Some(chrono::NaiveDateTime::from(course_row.posted_time.unwrap())),
+        })
+    } else {
+        Err(EzyTutorError::NotFound("Course id not found".into()))
+    }
+}
+
+pub async fn post_new_course_db(pool: &PgPool, new_course: Course)
+-> Result<Course, EzyTutorError> {
+    // SQL 구문 생성.
+    let course_row = sqlx::query!("INSERT INTO ezy_course_ch4 (
+    tutor_id, course_id, course_name) VALUES ($1, $2, $3) RETURNING tutor_id, course_id, course_name, posted_time", new_course.tutor_id, new_course.course_id, new_course.course_name)
+    .fetch_one(pool)
+    .await?;
+
+    Ok(Course {
+        tutor_id: course_row.tutor_id,
+        course_id: course_row.course_id,
+        course_name: course_row.course_name.clone(),
+        posted_time: Some(chrono::NaiveDateTime::from(course_row.posted_time.unwrap())),
+    })
+}

--- a/ezytutors/tutor-db/src/iter4/errors.rs
+++ b/ezytutors/tutor-db/src/iter4/errors.rs
@@ -1,0 +1,70 @@
+use actix_web::{error, http::StatusCode, HttpResponse, Result};
+use serde::Serialize;
+use sqlx::error::Error as SQLxError;
+use std::fmt;
+
+#[derive(Debug, Serialize)]
+pub enum EzyTutorError {
+    DBError(String),
+    ActixError(String),
+    NotFound(String),
+}
+
+#[derive(Debug, Serialize)]
+pub struct CustomErrorResponse {
+    error_message: String,
+}
+
+impl EzyTutorError {
+    fn error_response(&self) -> String {
+        match self {
+            EzyTutorError::DBError(msg) => {
+                println!("Database error occurred: {:?}", msg);
+                "Database error".into()
+            }
+            EzyTutorError::ActixError(msg) => {
+                println!("Server error occurred: {:?}", msg);
+                "Internal Server error".into()
+            }
+            EzyTutorError::NotFound(msg) => {
+                println!("Not found error occurred: {:?}", msg);
+                msg.into()
+            }
+        }
+    }
+}
+
+impl error::ResponseError for EzyTutorError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            EzyTutorError::DBError(_msg) | EzyTutorError::ActixError(_msg) => {
+                StatusCode::INTERNAL_SERVER_ERROR // => 500
+            }
+            EzyTutorError::NotFound(_msg) => StatusCode::NOT_FOUND // => 404
+        }
+    }
+
+    fn error_response(&self) -> HttpResponse {
+        HttpResponse::build(self.status_code()).json(CustomErrorResponse {
+            error_message: self.error_response(),
+        })
+    }
+}
+
+impl fmt::Display for EzyTutorError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{}", self)
+    }
+}
+
+impl From<actix_web::error::Error> for EzyTutorError {
+    fn from(err: actix_web::error::Error) -> Self {
+        EzyTutorError::ActixError(err.to_string())
+    }
+}
+
+impl From<SQLxError> for EzyTutorError {
+    fn from(err: SQLxError) -> Self {
+        EzyTutorError::DBError(err.to_string())
+    }
+}

--- a/ezytutors/tutor-db/src/iter4/handlers.rs
+++ b/ezytutors/tutor-db/src/iter4/handlers.rs
@@ -1,0 +1,130 @@
+use super::errors::EzyTutorError;
+use super::db_access::*;
+use super::models::Course;
+use super::state::AppState;
+use actix_web::{web, HttpResponse};
+
+pub async fn health_check_handler(app_state: web::Data<AppState>) -> HttpResponse {
+    let health_check_response = &app_state.health_check_response;
+    let mut visit_count = app_state.visit_count.lock().unwrap();
+    let response = format!("{} {} times", health_check_response, visit_count);
+    *visit_count += 1;
+    
+    HttpResponse::Ok().json(&response)
+}
+
+pub async fn get_courses_for_tutor(
+    app_state: web::Data<AppState>,
+    path: web::Path<i32>,
+) -> Result<HttpResponse, EzyTutorError> {
+    let tutor_id = path.into_inner();
+    get_courses_for_tutor_db(&app_state.db, tutor_id)
+        .await
+        .map(|courses| HttpResponse::Ok().json(courses))
+}
+
+pub async fn get_course_for_details(
+    app_state: web::Data<AppState>,
+    path: web::Path<(i32, i32)>,
+) -> Result<HttpResponse, EzyTutorError> {
+    let (tutor_id, course_id) = path.into_inner();
+    get_course_for_details_db(&app_state.db, tutor_id, course_id)
+        .await
+        .map(|course| HttpResponse::Ok().json(course))
+}
+
+pub async fn post_new_course(
+    app_state: web::Data<AppState>,
+    new_course: web::Json<Course>,
+) -> Result<HttpResponse, EzyTutorError> {
+    
+    post_new_course_db(&app_state.db, new_course.into())
+        .await
+        .map(|course| HttpResponse::Ok().json(course))
+}
+
+// 각 핸들러 함수 단위 테스트.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::http::StatusCode;
+    use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
+    use dotenv::dotenv;
+    use sqlx::postgres::PgPool;
+    use std::env;
+    use std::sync::Mutex;
+
+    #[actix_rt::test]
+    async fn get_all_courses_success() {
+        dotenv().ok();
+
+        let database_url = env::var("DATABASE_URL").expect(
+            "DATABASE_URL is not set in .env file");
+
+        let pool = PgPool::connect(&database_url).await.unwrap();
+
+        let app_state: web::Data<AppState> = web::Data::new(AppState {
+            health_check_response: "".to_string(),
+            visit_count: Mutex::new(0),
+            db: pool,
+        });
+
+        let tutor_id = web::Path::from(1);
+        let resp = get_courses_for_tutor(app_state, tutor_id).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[actix_rt::test]
+    async fn get_course_details_test() {
+        dotenv().ok();
+
+        let database_url = env::var("DATABASE_URL").expect(
+            "DATABASE_URL is not set in .env file");
+
+        let pool = PgPool::connect(&database_url).await.unwrap();
+
+        let app_state = web::Data::new(AppState {
+            health_check_response: "".to_string(),
+            visit_count: Mutex::new(0),
+            db: pool,
+        });
+
+        let params = web::Path::from((1, 2));
+        let resp = get_course_for_details(app_state, params).await.unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[ignore]
+    #[actix_rt::test]
+    async fn post_course_success() {
+        dotenv().ok();
+
+        let database_url = env::var("DATABASE_URL").expect(
+            "DATABASE_URL is not set in .env file");
+
+        let pool = PgPool::connect(&database_url).await.unwrap();
+
+        let app_state = web::Data::new(AppState {
+            health_check_response: "".to_string(),
+            visit_count: Mutex::new(0),
+            db: pool,
+        });
+
+        let date = NaiveDate::from_ymd_opt(2024, 9, 3).unwrap();
+        let time = NaiveTime::from_hms_opt(21, 31, 33).unwrap();
+        let posted_time = NaiveDateTime::new(date, time);
+
+        let new_course_msg = Course {
+            course_id: 9,
+            tutor_id: 1,
+            course_name: "모든 개발자를 위한 HTTP 웹 기본 지식".into(),
+            posted_time: Some(posted_time),
+        };
+
+        let course_param = web::Json(new_course_msg);
+        let resp = post_new_course(app_state, course_param).await.unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}

--- a/ezytutors/tutor-db/src/iter4/models.rs
+++ b/ezytutors/tutor-db/src/iter4/models.rs
@@ -1,0 +1,22 @@
+use actix_web::web;
+use chrono::NaiveDateTime;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct Course {
+    pub tutor_id: i32,
+    pub course_id: i32,
+    pub course_name: String,
+    pub posted_time: Option<NaiveDateTime>,
+}
+
+impl From<web::Json<Course>> for Course {
+    fn from(course: web::Json<Course>) -> Self {
+        Course {
+            tutor_id: course.tutor_id,
+            course_id: course.course_id,
+            course_name: course.course_name.clone(),
+            posted_time: course.posted_time,
+        }
+    }
+}

--- a/ezytutors/tutor-db/src/iter4/routes.rs
+++ b/ezytutors/tutor-db/src/iter4/routes.rs
@@ -1,0 +1,17 @@
+use super::handlers::*;
+use actix_web::web;
+
+// 헬스 체크같은 보편적인 라우트.
+pub fn general_routes(cfg: &mut web::ServiceConfig) {
+    cfg.route("/health", web::get().to(health_check_handler));
+}
+
+// 강의 관련 라우트.
+pub fn course_routes(cfg: &mut web::ServiceConfig) {
+    cfg.service(
+        web::scope("/courses")
+            .route("/", web::post().to(post_new_course))
+            .route("/{tutor_id}", web::get().to(get_courses_for_tutor))
+            .route("/{tutor_id}/{course_id}", web::get().to(get_course_for_details)),
+    );
+}

--- a/ezytutors/tutor-db/src/iter4/state.rs
+++ b/ezytutors/tutor-db/src/iter4/state.rs
@@ -1,0 +1,8 @@
+use sqlx::postgres::PgPool;
+use std::sync::Mutex;
+
+pub struct AppState {
+    pub health_check_response: String,
+    pub visit_count: Mutex<u32>,
+    pub db: PgPool,
+}


### PR DESCRIPTION
발생할 수 있는 여러 타입 에러들을 커스텀 에러 타입에 정의하고 변환하도록 처리.
그리고 각 에러가 발생했을 때, HTTP response 메시지로 전달해서 클라이언트 측에서 인지할 수 있게 함.

sqlx 에러, actix web 에러, invalid 요청 에러를 커스텀 에러 타입으로 묶어 정의.
```
pub enum EzyTutorError {
    DBError(String),
    ActixError(String),
    NotFound(String),
}
```